### PR TITLE
`$using` statements require lower case

### DIFF
--- a/.github/workflows/ondemand publish.yml
+++ b/.github/workflows/ondemand publish.yml
@@ -16,6 +16,6 @@ jobs:
 
     - name: Publish to Gallery
       shell: pwsh
-      run: .\publish.ps1
+      run: .\publish.ps1 PSParallelPipeline
       env:
         PSGALLERY_TOKEN: ${{ secrets.PSGALLERY_TOKEN }}

--- a/.github/workflows/release publish.yml
+++ b/.github/workflows/release publish.yml
@@ -20,6 +20,6 @@ jobs:
 
     - name: Publish to Gallery
       shell: pwsh
-      run: .\publish.ps1
+      run: .\publish.ps1 PSParallelPipeline
       env:
         PSGALLERY_TOKEN: ${{ secrets.PSGALLERY_TOKEN }}

--- a/PSParallelPipeline/PSParallelPipeline.psd1
+++ b/PSParallelPipeline/PSParallelPipeline.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSParallelPipeline.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PSParallelPipeline/PSParallelPipeline.psm1
+++ b/PSParallelPipeline/PSParallelPipeline.psm1
@@ -148,6 +148,8 @@ function Invoke-Parallel {
 
             $usingParams = @{}
 
+            # Credits to mklement0 for catching up a bug here. Thank you!
+            # https://github.com/mklement0
             foreach($usingstatement in $ScriptBlock.Ast.FindAll({ $args[0] -is [UsingExpressionAst] }, $true)) {
                 $varText = $usingstatement.Extent.Text
                 $varPath = $usingstatement.SubExpression.VariablePath.UserPath

--- a/PSParallelPipeline/PSParallelPipeline.psm1
+++ b/PSParallelPipeline/PSParallelPipeline.psm1
@@ -152,11 +152,9 @@ function Invoke-Parallel {
                 $varText = $usingstatement.Extent.Text
                 $varPath = $usingstatement.SubExpression.VariablePath.UserPath
 
-                # Credits to mklement0 for catching up a bug here. Thank you!
-                # https://github.com/mklement0
-                $key = [Convert]::ToBase64String([Encoding]::Unicode.GetBytes($varText))
+                $key = [Convert]::ToBase64String([Encoding]::Unicode.GetBytes($varText.ToLower()))
                 if(-not $usingParams.ContainsKey($key)) {
-                    $usingParams.Add($key, $ExecutionContext.SessionState.PSVariable.Get($varPath).Value)
+                    $usingParams.Add($key, $ExecutionContext.SessionState.PSVariable.GetValue($varPath))
                 }
             }
 
@@ -177,7 +175,8 @@ function Invoke-Parallel {
                 $args[0].InvokeWithContext($null, [psvariable]::new('_', $args[1]))
             }).AddArgument($ScriptBlock.Ast.GetScriptBlock()).AddArgument($InputObject)
 
-            # This is how `Start-Job` does it's magic. Credits to Jordan Borean for his help here.
+            # This is how `Start-Job` does it's magic.
+            # Credits to Jordan Borean for his help here.
             # https://github.com/jborean93
 
             # Reference in the source code:

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,1 +1,4 @@
-﻿Publish-Module -Path $PSScriptRoot -NuGetApiKey $env:PSGALLERY_TOKEN
+﻿param([string] $ModuleName)
+
+$path = Join-Path $PSScriptRoot -ChildPath $ModuleName
+Publish-Module -Path $path -NuGetApiKey $env:PSGALLERY_TOKEN


### PR DESCRIPTION
Fixes #3 

Passing arguments via the stop-parsing token ( `--%` ) requires that all Keys are lower case.

Updated [Line #157](https://github.com/santisq/PSParallelPipeline/blob/main/PSParallelPipeline.psm1#L157) from:

```powershell
$key = [Convert]::ToBase64String([Encoding]::Unicode.GetBytes($varText))
```

To:

```powershell
$key = [Convert]::ToBase64String([Encoding]::Unicode.GetBytes($varText.ToLower()))
```