### PR TITLE
scriptblock checks

### DIFF
--- a/Module/PSParallelPipeline.psd1
+++ b/Module/PSParallelPipeline.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'PSParallelPipeline.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.2'
+    ModuleVersion     = '1.1.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -120,5 +120,19 @@
             }
 
         }
+
+        It 'Should throw if passing a scriptblock with using: scope modifier' {
+            {
+                $sb = { }
+                1..1 | Invoke-Parallel { $using:sb }
+            } | Should -Throw
+        }
+
+        It 'Should throw if passing a scriptblock with the -Variables parameter' {
+            {
+                $sb = { }
+                1..1 | Invoke-Parallel { $sb } -Variables @{ sb = $sb }
+            } | Should -Throw
+        }
     }
 }


### PR DESCRIPTION
- Added check to validate if a scriptblock is being passed to the parallel scope either through `using:` scope modifier or `-Varables` parameter. In both cases there will be a terminating error.
- Added pester tests.