### PR TITLE
Fixes incorrect error message on passed ScriptBlock by `-Variables`

### DIFF
--- a/module/PSParallelPipeline.psd1
+++ b/module/PSParallelPipeline.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'bin/netstandard2.0/PSParallelPipeline.dll'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.6'
+    ModuleVersion     = '1.1.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSParallelPipeline/Extensions.cs
+++ b/src/PSParallelPipeline/Extensions.cs
@@ -39,7 +39,7 @@ internal static class Extensions
     {
         foreach (DictionaryEntry pair in variables)
         {
-            cmdlet.ThrowIfUsingValueIsScriptBlock(pair.Value);
+            cmdlet.ThrowIfVariableIsScriptBlock(pair.Value);
             initialSessionState.Variables.Add(new SessionStateVariableEntry(
                 name: LanguagePrimitives.ConvertTo<string>(pair.Key),
                 value: pair.Value,


### PR DESCRIPTION
Fixes incorrect method call on `AddVariables` extension method.

### Invoke-Parallel v1.1.6

```powershell
PS \> $null = Invoke-Parallel { $var } -Variables @{ var = {} }
# Invoke-Parallel: A $using: variable cannot be a script block. Passed-in script block variables are not supported, and can result in undefined behavior.
```

### Invoke-Parallel v1.1.7

```powershell
PS \> $null = Invoke-Parallel { $var } -Variables @{ var = {} }
# Invoke-Parallel: Passed-in script block variables are not supported, and can result in undefined behavior.
```