### PR TITLE
Fixes `Invoke-Parallel` not disposing Runspaces

### DIFF
--- a/module/PSParallelPipeline.psd1
+++ b/module/PSParallelPipeline.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'bin/netstandard2.0/PSParallelPipeline.dll'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.7'
+    ModuleVersion     = '1.1.8'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSParallelPipeline/ExceptionHelpers.cs
+++ b/src/PSParallelPipeline/ExceptionHelpers.cs
@@ -15,10 +15,6 @@ internal static class ExceptionHelpers
             ErrorCategory.OperationTimeout,
             cmdlet));
 
-    // internal static void WriteEndProcessingError(this Exception exception, PSCmdlet cmdlet) =>
-    //     cmdlet.WriteError(new ErrorRecord(
-    //         exception, "EndProcessingOutput", ErrorCategory.NotSpecified, cmdlet));
-
     internal static void WriteUnspecifiedError(this Exception exception, PSCmdlet cmdlet) =>
         cmdlet.WriteError(new ErrorRecord(
             exception, "UnspecifiedCmdletError", ErrorCategory.NotSpecified, cmdlet));

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -96,7 +96,7 @@ internal sealed class PSTask : IDisposable
         {
             task._powershell.EndStop(e);
             task.Runspace.Dispose();
-            // task.Dispose();
+            task.Dispose();
         }, null);
     };
 

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -19,32 +19,34 @@ internal sealed class PSTask : IDisposable
 
     private readonly PowerShell _powershell;
 
-    private readonly PSDataStreams _streams;
+    private readonly PSDataStreams _internalStreams;
 
     private readonly RunspacePool _pool;
 
     private PSTask(RunspacePool runspacePool)
     {
         _powershell = PowerShell.Create();
-        _streams = _powershell.Streams;
+        _internalStreams = _powershell.Streams;
         _pool = runspacePool;
     }
 
     static internal PSTask Create(RunspacePool runspacePool)
     {
         PSTask ps = new(runspacePool);
-        HookStreams(ps, runspacePool.PSOutputStreams);
+        HookStreams(ps._internalStreams, runspacePool.PSOutputStreams);
         return ps;
     }
 
-    private static void HookStreams(PSTask ps, PSOutputStreams outputStreams)
+    private static void HookStreams(
+        PSDataStreams streams,
+        PSOutputStreams outputStreams)
     {
-        ps._streams.Error = outputStreams.Error;
-        ps._streams.Debug = outputStreams.Debug;
-        ps._streams.Information = outputStreams.Information;
-        ps._streams.Progress = outputStreams.Progress;
-        ps._streams.Verbose = outputStreams.Verbose;
-        ps._streams.Warning = outputStreams.Warning;
+        streams.Error = outputStreams.Error;
+        streams.Debug = outputStreams.Debug;
+        streams.Information = outputStreams.Information;
+        streams.Progress = outputStreams.Progress;
+        streams.Verbose = outputStreams.Verbose;
+        streams.Warning = outputStreams.Warning;
     }
 
     private static Task InvokePowerShellAsync(
@@ -94,7 +96,7 @@ internal sealed class PSTask : IDisposable
         {
             task._powershell.EndStop(e);
             task.Runspace.Dispose();
-            task.Dispose();
+            // task.Dispose();
         }, null);
     };
 

--- a/src/PSParallelPipeline/RunspacePool.cs
+++ b/src/PSParallelPipeline/RunspacePool.cs
@@ -8,9 +8,9 @@ namespace PSParallelPipeline;
 
 internal sealed class RunspacePool : IDisposable
 {
-    internal PSOutputStreams PSOutputStreams { get => _woker.OutputStreams; }
+    internal PSOutputStreams PSOutputStreams { get => _worker.OutputStreams; }
 
-    private CancellationToken Token { get => _woker.Token; }
+    private CancellationToken Token { get => _worker.Token; }
 
     private InitialSessionState InitialSessionState { get => _settings.InitialSessionState; }
 
@@ -28,12 +28,14 @@ internal sealed class RunspacePool : IDisposable
 
     private readonly PoolSettings _settings;
 
-    private readonly Worker _woker;
+    private readonly Worker _worker;
+
+    private readonly List<Runspace> _createdRunspaces = [];
 
     internal RunspacePool(PoolSettings settings, Worker worker)
     {
         _settings = settings;
-        _woker = worker;
+        _worker = worker;
         _pool = new Queue<Runspace>(MaxRunspaces);
         _tasks = new List<Task<PSTask>>(MaxRunspaces);
     }
@@ -42,6 +44,7 @@ internal sealed class RunspacePool : IDisposable
     {
         Runspace rs = RunspaceFactory.CreateRunspace(InitialSessionState);
         rs.Open();
+        _createdRunspaces.Add(rs);
         return rs;
     }
 
@@ -122,9 +125,12 @@ internal sealed class RunspacePool : IDisposable
 
     public void Dispose()
     {
-        foreach (Runspace runspace in _pool)
+        foreach (Runspace runspace in _createdRunspaces)
         {
-            runspace.Dispose();
+            if (runspace is { RunspaceAvailability: RunspaceAvailability.Available })
+            {
+                runspace.Dispose();
+            }
         }
 
         GC.SuppressFinalize(this);

--- a/src/PSParallelPipeline/RunspacePool.cs
+++ b/src/PSParallelPipeline/RunspacePool.cs
@@ -30,7 +30,7 @@ internal sealed class RunspacePool : IDisposable
 
     private readonly Worker _worker;
 
-    private readonly List<Runspace> _createdRunspaces = [];
+    private readonly List<Runspace> _createdRunspaces;
 
     internal RunspacePool(PoolSettings settings, Worker worker)
     {
@@ -38,6 +38,7 @@ internal sealed class RunspacePool : IDisposable
         _worker = worker;
         _pool = new Queue<Runspace>(MaxRunspaces);
         _tasks = new List<Task<PSTask>>(MaxRunspaces);
+        _createdRunspaces = new List<Runspace>(MaxRunspaces);
     }
 
     private Runspace CreateRunspace()

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -266,14 +266,8 @@ Describe PSParallelPipeline {
                     AddScript('1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100')
                     $ps.Runspace = $rs
                     $timer = [Stopwatch]::StartNew()
-                    $async = $ps.BeginInvoke()
-
-                    if ($IsCoreCLR) {
-                        $async = $ps.BeginStop($ps.EndStop, $null)
-                    }
-                    else {
-                        $ps.Stop()
-                    }
+                    $null = $ps.BeginInvoke()
+                    $ps.Stop()
 
                     while ($ps.InvocationStateInfo.State -eq [PSInvocationState]::Running) {
                         Start-Sleep -Milliseconds 50

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -149,7 +149,7 @@ Describe PSParallelPipeline {
                     1..100 | Invoke-Parallel @invokeParallelSplat
                 } | Should -Throw -ExceptionType ([TimeoutException])
                 $timer.Stop()
-                $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(2.1))
+                $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(2.2))
             }
         }
     }

--- a/tests/common.psm1
+++ b/tests/common.psm1
@@ -15,3 +15,20 @@ function Complete {
             $null).CompletionMatches
     }
 }
+
+function Assert-RunspaceCount {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock] $ScriptBlock
+    )
+
+    try {
+        $count = @(Get-Runspace).Count
+        & $ScriptBlock
+    }
+    finally {
+        Get-Runspace |
+            Should -HaveCount $count -Because 'Runspaces should be correctly disposed'
+    }
+}


### PR DESCRIPTION
This PR fixes the issue where the cmdlet would not be correctly disposing runspaces in scenarios where a `PipelineStoppedException` was thrown (<kbd>CTRL+C</kbd> / `Select-Object -First`) and `OperationCanceledException` (Timeout reached).