### PR TITLE
Fixes `Invoke-Parallel` not disposing Runspaces, take 2

### DIFF
--- a/module/PSParallelPipeline.psd1
+++ b/module/PSParallelPipeline.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'bin/netstandard2.0/PSParallelPipeline.dll'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.8'
+    ModuleVersion     = '1.1.9'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
+++ b/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
@@ -95,7 +95,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
-            _worker.Wait();
+            _worker.WaitOperationCanceled();
             exception.WriteTimeoutError(this);
         }
         catch (Exception exception)
@@ -125,7 +125,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
-            _worker.Wait();
+            _worker.WaitOperationCanceled();
             exception.WriteTimeoutError(this);
         }
         catch (Exception exception)

--- a/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
+++ b/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
@@ -95,6 +95,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
+            _worker.Wait();
             exception.WriteTimeoutError(this);
         }
         catch (Exception exception)
@@ -124,6 +125,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
+            _worker.Wait();
             exception.WriteTimeoutError(this);
         }
         catch (Exception exception)

--- a/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
+++ b/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
@@ -90,7 +90,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (Exception _) when (_ is PipelineStoppedException or FlowControlException)
         {
-            _worker.Stop();
+            _worker.StopAndWait();
             throw;
         }
         catch (OperationCanceledException exception)
@@ -119,7 +119,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (Exception _) when (_ is PipelineStoppedException or FlowControlException)
         {
-            _worker.Stop();
+            _worker.StopAndWait();
             throw;
         }
         catch (OperationCanceledException exception)
@@ -166,7 +166,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
     }
 
-    protected override void StopProcessing() => _worker?.Stop();
+    protected override void StopProcessing() => _worker?.StopAndWait();
 
     public void Dispose()
     {

--- a/src/PSParallelPipeline/Extensions.cs
+++ b/src/PSParallelPipeline/Extensions.cs
@@ -140,4 +140,9 @@ internal static class Extensions
             .GetScriptBlock()
             .InvokeReturnAsIs();
     }
+
+    internal static void Deconstruct<TKey, TValue>(
+        this KeyValuePair<TKey, TValue> pair,
+        out TKey key,
+        out TValue value) => (key, value) = (pair.Key, pair.Value);
 }

--- a/src/PSParallelPipeline/Extensions.cs
+++ b/src/PSParallelPipeline/Extensions.cs
@@ -140,9 +140,4 @@ internal static class Extensions
             .GetScriptBlock()
             .InvokeReturnAsIs();
     }
-
-    internal static void Deconstruct<TKey, TValue>(
-        this KeyValuePair<TKey, TValue> pair,
-        out TKey key,
-        out TValue value) => (key, value) = (pair.Key, pair.Value);
 }

--- a/src/PSParallelPipeline/PSOutputStreams.cs
+++ b/src/PSParallelPipeline/PSOutputStreams.cs
@@ -30,12 +30,12 @@ internal sealed class PSOutputStreams : IDisposable
     internal PSOutputStreams(Worker worker)
     {
         _worker = worker;
-        SetStreams(this);
+        SetStreamHandlers(this);
     }
 
     internal void AddOutput(PSOutputData data) => OutputPipe.Add(data, Token);
 
-    private static void SetStreams(PSOutputStreams outputStreams)
+    private static void SetStreamHandlers(PSOutputStreams outputStreams)
     {
         outputStreams.Success.DataAdded += (s, e) =>
         {

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -93,20 +93,16 @@ internal sealed class PSTask : IDisposable
         return this;
     }
 
-    private static Action CancelCallback(PSTask task) => async delegate
+    private static Action CancelCallback(PSTask task) => delegate
     {
-        await Task.Factory.FromAsync(
-            beginMethod: task._powershell.BeginStop,
-            endMethod: task._powershell.EndStop,
-            state: null);
-
+        task.Dispose();
         task._pool.RemoveTask(task);
     };
 
     public void Dispose()
     {
-        _pool.RemoveTask(this);
         _powershell.Dispose();
+        _pool.RemoveTask(this);
         GC.SuppressFinalize(this);
     }
 }

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -96,13 +96,13 @@ internal sealed class PSTask : IDisposable
     private static Action CancelCallback(PSTask task) => delegate
     {
         task.Dispose();
+        task.Runspace.Dispose();
         task._pool.RemoveTask(task);
     };
 
     public void Dispose()
     {
         _powershell.Dispose();
-        _pool.RemoveTask(this);
         GC.SuppressFinalize(this);
     }
 }

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -87,18 +87,12 @@ internal sealed class PSTask : IDisposable
 
     internal async Task<PSTask> InvokeAsync()
     {
-        _pool.AddTask(this);
         using CancellationTokenRegistration _ = _pool.RegisterCancellation(CancelCallback(this));
         await InvokePowerShellAsync(_powershell, OutputStreams.Success);
         return this;
     }
 
-    private static Action CancelCallback(PSTask task) => delegate
-    {
-        task.Dispose();
-        task.Runspace.Dispose();
-        task._pool.RemoveTask(task);
-    };
+    private static Action CancelCallback(PSTask task) => task.Dispose;
 
     public void Dispose()
     {

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -23,8 +23,6 @@ internal sealed class PSTask : IDisposable
         set => _powershell.Runspace = value;
     }
 
-    internal Guid Id { get => _powershell.InstanceId; }
-
     private PSTask(RunspacePool runspacePool)
     {
         _powershell = PowerShell.Create();
@@ -92,7 +90,11 @@ internal sealed class PSTask : IDisposable
         return this;
     }
 
-    private static Action CancelCallback(PSTask task) => task.Dispose;
+    private static Action CancelCallback(PSTask task) => delegate
+    {
+        task.Dispose();
+        task.Runspace.Dispose();
+    };
 
     public void Dispose()
     {

--- a/src/PSParallelPipeline/RunspacePool.cs
+++ b/src/PSParallelPipeline/RunspacePool.cs
@@ -108,10 +108,6 @@ internal sealed class RunspacePool : IDisposable
             _pool.Enqueue(runspace);
             pSTask = await awaiter;
         }
-        catch (Exception _) when (_ is TaskCanceledException or OperationCanceledException)
-        {
-            throw;
-        }
         catch (Exception exception)
         {
             PSOutputStreams.AddOutput(exception.CreateProcessingTaskError(this));

--- a/src/PSParallelPipeline/TaskManager.cs
+++ b/src/PSParallelPipeline/TaskManager.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Management.Automation.Runspaces;
+using System.Threading.Tasks;
+
+namespace PSParallelPipeline;
+
+internal sealed class TaskManager
+{
+    private readonly List<Task<PSTask>> _tasks;
+
+    private readonly Dictionary<int, Runspace> _assignedRunspaces;
+
+    private readonly int _maxRunspaces;
+
+    internal bool ShouldProcess { get => _tasks.Count == _maxRunspaces; }
+
+    internal bool HasMoreTasks { get => _tasks.Count > 0; }
+
+    internal TaskManager(int maxRunspaces)
+    {
+        _maxRunspaces = maxRunspaces;
+        _tasks = new List<Task<PSTask>>(maxRunspaces);
+        _assignedRunspaces = new Dictionary<int, Runspace>(maxRunspaces);
+    }
+
+    internal void Enqueue(PSTask psTask)
+    {
+        Task<PSTask> task = psTask.InvokeAsync();
+        _assignedRunspaces[task.Id] = psTask.Runspace;
+        _tasks.Add(task);
+    }
+
+    internal Task<Task<PSTask>> WhenAny() => Task.WhenAny(_tasks);
+
+    internal Runspace Dequeue(Task<PSTask> psTask)
+    {
+        Runspace runspace = _assignedRunspaces[psTask.Id];
+        _assignedRunspaces.Remove(psTask.Id);
+        _tasks.Remove(psTask);
+        return runspace;
+    }
+}

--- a/src/PSParallelPipeline/Worker.cs
+++ b/src/PSParallelPipeline/Worker.cs
@@ -37,6 +37,11 @@ internal sealed class Worker : IDisposable
 
     internal void Wait() => _worker?.GetAwaiter().GetResult();
 
+    internal void WaitOperationCanceled() =>
+        _worker?
+            .ContinueWith(e => { }, TaskContinuationOptions.OnlyOnCanceled)
+            .Wait();
+
     internal void StopAndWait()
     {
         _cts.Cancel();

--- a/src/PSParallelPipeline/Worker.cs
+++ b/src/PSParallelPipeline/Worker.cs
@@ -68,7 +68,7 @@ internal sealed class Worker : IDisposable
     {
         while (!_inputQueue.IsCompleted)
         {
-            if (_inputQueue.TryTake(out PSTask ps, 200, Token))
+            if (_inputQueue.TryTake(out PSTask ps, 0, Token))
             {
                 await _runspacePool.EnqueueAsync(ps);
             }

--- a/src/PSParallelPipeline/Worker.cs
+++ b/src/PSParallelPipeline/Worker.cs
@@ -64,12 +64,10 @@ internal sealed class Worker : IDisposable
     {
         while (!_inputQueue.IsCompleted)
         {
-            if (!_inputQueue.TryTake(out PSTask ps, 0, Token))
+            if (_inputQueue.TryTake(out PSTask ps, 200, Token))
             {
-                continue;
+                await _runspacePool.EnqueueAsync(ps);
             }
-
-            await _runspacePool.EnqueueAsync(ps);
         }
 
         await _runspacePool.ProcessTasksAsync();

--- a/src/PSParallelPipeline/Worker.cs
+++ b/src/PSParallelPipeline/Worker.cs
@@ -37,7 +37,11 @@ internal sealed class Worker : IDisposable
 
     internal void Wait() => _worker?.GetAwaiter().GetResult();
 
-    internal void Stop() => _cts.Cancel();
+    internal void StopAndWait()
+    {
+        _cts.Cancel();
+        Wait();
+    }
 
     internal void CancelAfter(TimeSpan span) => _cts.CancelAfter(span);
 

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -137,12 +137,6 @@ Describe PSParallelPipeline {
 
     Context 'TimeoutSeconds Parameter' {
         It 'Stops processing after the specified seconds' {
-            # $wait = 5
-            # if (-not $IsCoreCLR) {
-            #     # because pwsh 5.1 fucking sucks!
-            #     $wait = 10
-            # }
-
             Assert-RunspaceCount {
                 $timer = [Stopwatch]::StartNew()
                 {
@@ -156,7 +150,7 @@ Describe PSParallelPipeline {
                 } | Should -Throw -ExceptionType ([TimeoutException])
                 $timer.Stop()
                 $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(2.2))
-            } # -WaitSeconds $wait
+            }
         }
     }
 
@@ -294,7 +288,7 @@ Describe PSParallelPipeline {
                     $scripts | ForEach-Object {
                         $ps = $ps.AddScript($script).AddStatement()
                     }
-                    $timer = [System.Diagnostics.Stopwatch]::StartNew()
+                    $timer = [Stopwatch]::StartNew()
                     $task = $ps.BeginInvoke()
                     Start-Sleep 1
                     $ps.Stop()

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -137,11 +137,11 @@ Describe PSParallelPipeline {
 
     Context 'TimeoutSeconds Parameter' {
         It 'Stops processing after the specified seconds' {
-            $wait = 5
-            if (-not $IsCoreCLR) {
-                # because pwsh 5.1 fucking sucks!
-                $wait = 10
-            }
+            # $wait = 5
+            # if (-not $IsCoreCLR) {
+            #     # because pwsh 5.1 fucking sucks!
+            #     $wait = 10
+            # }
 
             Assert-RunspaceCount {
                 $timer = [Stopwatch]::StartNew()
@@ -156,7 +156,7 @@ Describe PSParallelPipeline {
                 } | Should -Throw -ExceptionType ([TimeoutException])
                 $timer.Stop()
                 $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(2.2))
-            } -WaitSeconds $wait
+            } # -WaitSeconds $wait
         }
     }
 
@@ -174,7 +174,7 @@ Describe PSParallelPipeline {
         }
     }
 
-    Context '$using: scope modifier Support' {
+    Context '$using: scope modifier' {
         It 'Allows passed-in variables through the $using: scope modifier' {
             $message = 'Hello world from {0:D2}'
             $items = 0..10 | Invoke-Parallel { $using:message -f $_ } |
@@ -232,7 +232,14 @@ Describe PSParallelPipeline {
                     Select-Object -First 10
             }
 
-            $testOne, $testTwo | Out-Null
+            $testThree = {
+                1..100 |
+                    ForEach-Object { $_; Start-Sleep -Milliseconds 200 } |
+                    Invoke-Parallel { $_ } |
+                    Select-Object -First 10
+            }
+
+            $testOne, $testTwo, $testThree | Out-Null
         }
 
         It 'Process in parallel' {
@@ -251,6 +258,10 @@ Describe PSParallelPipeline {
                 Measure-Command { & $testTwo | Should -HaveCount 10 } |
                     ForEach-Object TotalSeconds |
                     Should -BeLessThan 6
+
+                Measure-Command { & $testThree | Should -HaveCount 10 } |
+                    ForEach-Object TotalSeconds |
+                    Should -BeLessThan 3
             }
         }
 
@@ -262,31 +273,78 @@ Describe PSParallelPipeline {
 
             $dict[$PID].ProcessName | Should -Be (Get-Process -Id $PID).ProcessName
         }
+    }
 
-        It 'Stops processing on CTRL+C' {
+    Context 'Runspace Disposal Assertions' {
+        It 'Disposes on CTRL+C' {
+            $rs = [runspacefactory]::CreateRunspace()
+            $rs.Open()
+
             Assert-RunspaceCount {
+                param([runspace] $runspace)
+
+                $scripts = @(
+                    '1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100'
+                    '1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100 -UseNewRunspace'
+                )
+
                 try {
-                    $rs = [runspacefactory]::CreateRunspace()
-                    $rs.Open()
-                    $ps = [powershell]::Create().
-                    AddScript('1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100')
-                    $ps.Runspace = $rs
-                    $timer = [Stopwatch]::StartNew()
-                    $null = $ps.BeginInvoke()
-                    $ps.Stop()
-
-                    while ($ps.InvocationStateInfo.State -eq [PSInvocationState]::Running) {
-                        Start-Sleep -Milliseconds 50
+                    $ps = [powershell]::Create()
+                    $ps.Runspace = $runspace
+                    $scripts | ForEach-Object {
+                        $ps = $ps.AddScript($script).AddStatement()
                     }
-
+                    $timer = [System.Diagnostics.Stopwatch]::StartNew()
+                    $task = $ps.BeginInvoke()
+                    Start-Sleep 1
+                    $ps.Stop()
+                    while (-not $task.AsyncWaitHandle.WaitOne(200)) { }
                     $timer.Stop()
-                    $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(1))
+                    $timer.Elapsed | Should -BeLessOrEqual ([timespan]::FromSeconds(2))
                 }
                 finally {
                     $ps.Dispose()
-                    $rs.Dispose()
                 }
+            } -ArgumentList $rs -TestCount 10
+
+            $rs.Dispose()
+        }
+
+        It 'Disposes on PipelineStoppedException' {
+            $invokeParallelSplat = @{
+                ThrottleLimit = 11
+                ScriptBlock   = { $_ }
             }
+
+            Assert-RunspaceCount {
+                0..10 | Invoke-Parallel @invokeParallelSplat |
+                    Select-Object -First 1
+            } -TestCount 100
+
+            Assert-RunspaceCount {
+                $invokeParallelSplat['UseNewRunspace'] = $true
+                0..10 | Invoke-Parallel @invokeParallelSplat |
+                    Select-Object -First 1
+            } -TestCount 100
+        }
+
+        It 'Disposes on OperationCanceledException' {
+            $invokeParallelSplat = @{
+                ThrottleLimit  = 300
+                TimeOutSeconds = 1
+                ScriptBlock    = { Start-Sleep 1 }
+            }
+
+            Assert-RunspaceCount {
+                { 0..1000 | Invoke-Parallel @invokeParallelSplat } |
+                    Should -Throw
+            } -TestCount 50
+
+            Assert-RunspaceCount {
+                $invokeParallelSplat['UseNewRunspace'] = $true
+                { 0..1000 | Invoke-Parallel @invokeParallelSplat } |
+                    Should -Throw
+            } -TestCount 50
         }
     }
 }

--- a/tests/PSParallelPipeline.tests.ps1
+++ b/tests/PSParallelPipeline.tests.ps1
@@ -278,7 +278,7 @@ Describe PSParallelPipeline {
                 param([runspace] $runspace)
 
                 $scripts = @(
-                    '1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100'
+                    '1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 50'
                     '1..100 | Invoke-Parallel { Start-Sleep 1; $_ } -ThrottleLimit 100 -UseNewRunspace'
                 )
 
@@ -318,7 +318,7 @@ Describe PSParallelPipeline {
             Assert-RunspaceCount {
                 $invokeParallelSplat['UseNewRunspace'] = $true
                 0..10 | Invoke-Parallel @invokeParallelSplat |
-                    Select-Object -First 1
+                    Select-Object -First 10
             } -TestCount 100
         }
 
@@ -336,6 +336,7 @@ Describe PSParallelPipeline {
 
             Assert-RunspaceCount {
                 $invokeParallelSplat['UseNewRunspace'] = $true
+                $invokeParallelSplat['ThrottleLimit'] = 1001
                 { 0..1000 | Invoke-Parallel @invokeParallelSplat } |
                     Should -Throw
             } -TestCount 50

--- a/tests/common.psm1
+++ b/tests/common.psm1
@@ -23,16 +23,33 @@ function Assert-RunspaceCount {
         [scriptblock] $ScriptBlock,
 
         [Parameter()]
-        [int] $WaitSeconds = 5
+        [int] $WaitSeconds,
+
+        [Parameter()]
+        [object[]] $ArgumentList,
+
+        [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int] $TestCount = 1
     )
 
-    try {
-        $count = @(Get-Runspace).Count
-        & $ScriptBlock
-    }
-    finally {
-        Start-Sleep $WaitSeconds
-        Get-Runspace |
-            Should -HaveCount $count -Because 'Runspaces should be correctly disposed'
+    $count = @(Get-Runspace).Count
+    for ($i = 0; $i -lt $TestCount; $i++) {
+        try {
+            if ($ArgumentList) {
+                $null = & $ScriptBlock @ArgumentList
+                continue
+            }
+
+            $null = & $ScriptBlock
+        }
+        finally {
+            if ($WaitSeconds) {
+                Start-Sleep $WaitSeconds
+            }
+
+            Get-Runspace |
+                Should -HaveCount $count -Because 'Runspaces should be correctly disposed'
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issue where the cmdlet would not be correctly disposing runspaces in scenarios where a `PipelineStoppedException` was thrown (<kbd>CTRL+C</kbd> / `Select-Object -First`) and `OperationCanceledException` (Timeout reached).