### PR TITLE
Adds `ConfigureAwait(false)` to all `await` statements

### DIFF
--- a/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
+++ b/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
@@ -59,18 +59,12 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
             .AddFunctions(Functions, this)
             .AddVariables(Variables, this);
 
-        PoolSettings poolSettings = new()
-        {
-            MaxRunspaces = ThrottleLimit,
-            UseNewRunspace = UseNewRunspace,
-            InitialSessionState = iss
-        };
+        PoolSettings poolSettings = new(
+            ThrottleLimit, UseNewRunspace, iss);
 
-        TaskSettings workerSettings = new()
-        {
-            Script = ScriptBlock.ToString(),
-            UsingStatements = ScriptBlock.GetUsingParameters(this)
-        };
+        TaskSettings workerSettings = new(
+            ScriptBlock.ToString(),
+            ScriptBlock.GetUsingParameters(this));
 
         _worker = new Worker(poolSettings, workerSettings, _cts.Token);
         _worker.Run();

--- a/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
+++ b/src/PSParallelPipeline/Commands/InvokeParallelCommand.cs
@@ -90,7 +90,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
-            _worker.Wait();
+            _worker.WaitForCompletion();
             exception.WriteTimeoutError(this);
         }
     }
@@ -107,7 +107,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
                 ProcessOutput(data);
             }
 
-            _worker.Wait();
+            _worker.WaitForCompletion();
         }
         catch (Exception _) when (_ is PipelineStoppedException or FlowControlException)
         {
@@ -116,7 +116,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
         }
         catch (OperationCanceledException exception)
         {
-            _worker.Wait();
+            _worker.WaitForCompletion();
             exception.WriteTimeoutError(this);
         }
     }
@@ -125,33 +125,33 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
     {
         switch (data.Type)
         {
-            case Type.Success:
+            case OutputType.Success:
                 WriteObject(data.Output);
                 break;
 
-            case Type.Error:
+            case OutputType.Error:
                 WriteError((ErrorRecord)data.Output);
                 break;
 
-            case Type.Debug:
+            case OutputType.Debug:
                 DebugRecord debug = (DebugRecord)data.Output;
                 WriteDebug(debug.Message);
                 break;
 
-            case Type.Information:
+            case OutputType.Information:
                 WriteInformation((InformationRecord)data.Output);
                 break;
 
-            case Type.Progress:
+            case OutputType.Progress:
                 WriteProgress((ProgressRecord)data.Output);
                 break;
 
-            case Type.Verbose:
+            case OutputType.Verbose:
                 VerboseRecord verbose = (VerboseRecord)data.Output;
                 WriteVerbose(verbose.Message);
                 break;
 
-            case Type.Warning:
+            case OutputType.Warning:
                 WarningRecord warning = (WarningRecord)data.Output;
                 WriteWarning(warning.Message);
                 break;
@@ -161,7 +161,7 @@ public sealed class InvokeParallelCommand : PSCmdlet, IDisposable
     private void CancelAndWait()
     {
         _cts.Cancel();
-        _worker?.Wait();
+        _worker?.WaitForCompletion();
     }
 
     protected override void StopProcessing() => CancelAndWait();

--- a/src/PSParallelPipeline/OutputType.cs
+++ b/src/PSParallelPipeline/OutputType.cs
@@ -1,0 +1,12 @@
+namespace PSParallelPipeline;
+
+internal enum OutputType
+{
+    Success,
+    Error,
+    Debug,
+    Information,
+    Progress,
+    Verbose,
+    Warning
+}

--- a/src/PSParallelPipeline/PSOutputData.cs
+++ b/src/PSParallelPipeline/PSOutputData.cs
@@ -1,36 +1,25 @@
 namespace PSParallelPipeline;
 
-internal enum Type
-{
-    Success,
-    Error,
-    Debug,
-    Information,
-    Progress,
-    Verbose,
-    Warning
-}
-
-internal record struct PSOutputData(Type Type, object Output)
+internal record struct PSOutputData(OutputType Type, object Output)
 {
     internal static PSOutputData WriteObject(object sendToPipeline) =>
-        new(Type.Success, sendToPipeline);
+        new(OutputType.Success, sendToPipeline);
 
     internal static PSOutputData WriteError(object error) =>
-        new(Type.Error, error);
+        new(OutputType.Error, error);
 
     internal static PSOutputData WriteDebug(object debug) =>
-        new(Type.Debug, debug);
+        new(OutputType.Debug, debug);
 
     internal static PSOutputData WriteInformation(object information) =>
-        new(Type.Information, information);
+        new(OutputType.Information, information);
 
     internal static PSOutputData WriteProgress(object progress) =>
-        new(Type.Progress, progress);
+        new(OutputType.Progress, progress);
 
     internal static PSOutputData WriteVerbose(object verbose) =>
-        new(Type.Verbose, verbose);
+        new(OutputType.Verbose, verbose);
 
     internal static PSOutputData WriteWarning(object warning) =>
-        new(Type.Warning, warning);
+        new(OutputType.Warning, warning);
 }

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -37,7 +37,9 @@ internal sealed class PSTask
     {
         PSTask ps = new(runspacePool);
         SetStreams(ps._internalStreams, runspacePool.Streams);
-        ps.Runspace = await runspacePool.GetRunspaceAsync();
+        ps.Runspace = await runspacePool
+            .GetRunspaceAsync()
+            .ConfigureAwait(false);
 
         return ps
             .AddInput(input)
@@ -98,7 +100,7 @@ internal sealed class PSTask
         try
         {
             using CancellationTokenRegistration _ = _pool.RegisterCancellation(Cancel);
-            await InvokePowerShellAsync(_powershell, OutputStreams.Success);
+            await InvokePowerShellAsync(_powershell, OutputStreams.Success).ConfigureAwait(false);
         }
         catch (Exception exception)
         {

--- a/src/PSParallelPipeline/PSTask.cs
+++ b/src/PSParallelPipeline/PSTask.cs
@@ -9,42 +9,64 @@ namespace PSParallelPipeline;
 
 internal sealed class PSTask
 {
+    private const string SetVariableCommand = "Set-Variable";
+
+    private const string DollarUnderbar = "_";
+
+    private const string StopParsingOp = "--%";
+
     private readonly PowerShell _powershell;
 
     private readonly PSDataStreams _internalStreams;
 
+    private Runspace? _runspace;
+
+    private readonly PSOutputStreams _outputStreams;
+
+    private readonly CancellationToken _token;
+
     private readonly RunspacePool _pool;
-
-    private PSOutputStreams OutputStreams { get => _pool.Streams; }
-
-    private Runspace Runspace
-    {
-        get => _powershell.Runspace;
-        set => _powershell.Runspace = value;
-    }
 
     private PSTask(RunspacePool pool)
     {
         _powershell = PowerShell.Create();
         _internalStreams = _powershell.Streams;
+        _outputStreams = pool.Streams;
+        _token = pool.Token;
         _pool = pool;
     }
 
-    static internal async Task<PSTask> CreateAsync(
+    static internal PSTask Create(
         object? input,
         RunspacePool runspacePool,
         TaskSettings settings)
     {
         PSTask ps = new(runspacePool);
         SetStreams(ps._internalStreams, runspacePool.Streams);
-        ps.Runspace = await runspacePool
-            .GetRunspaceAsync()
-            .ConfigureAwait(false);
 
         return ps
             .AddInput(input)
             .AddScript(settings.Script)
             .AddUsingStatements(settings.UsingStatements);
+    }
+
+    internal async Task InvokeAsync()
+    {
+        try
+        {
+            using CancellationTokenRegistration _ = _token.Register(Cancel);
+            _runspace = await _pool.GetRunspaceAsync().ConfigureAwait(false);
+            _powershell.Runspace = _runspace;
+            await InvokePowerShellAsync(_powershell, _outputStreams.Success).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            _outputStreams.AddOutput(exception.CreateProcessingTaskError(this));
+        }
+        finally
+        {
+            CompleteTask();
+        }
     }
 
     private static void SetStreams(
@@ -71,8 +93,8 @@ internal sealed class PSTask
         if (inputObject is not null)
         {
             _powershell
-                .AddCommand("Set-Variable", useLocalScope: true)
-                .AddArgument("_")
+                .AddCommand(SetVariableCommand, useLocalScope: true)
+                .AddArgument(DollarUnderbar)
                 .AddArgument(inputObject);
         }
 
@@ -89,33 +111,27 @@ internal sealed class PSTask
     {
         if (usingParams.Count > 0)
         {
-            _powershell.AddParameter("--%", usingParams);
+            _powershell.AddParameter(StopParsingOp, usingParams);
         }
 
         return this;
     }
 
-    internal async Task InvokeAsync()
+    private void CompleteTask()
     {
-        try
+        _powershell.Dispose();
+        if (!_token.IsCancellationRequested && _runspace is not null)
         {
-            using CancellationTokenRegistration _ = _pool.RegisterCancellation(Cancel);
-            await InvokePowerShellAsync(_powershell, OutputStreams.Success).ConfigureAwait(false);
+            _pool.PushRunspace(_runspace);
+            return;
         }
-        catch (Exception exception)
-        {
-            OutputStreams.AddOutput(exception.CreateProcessingTaskError(this));
-        }
-        finally
-        {
-            _powershell.Dispose();
-            _pool.PushRunspace(Runspace);
-        }
+
+        _runspace?.Dispose();
     }
 
     private void Cancel()
     {
         _powershell.Dispose();
-        Runspace.Dispose();
+        _runspace?.Dispose();
     }
 }

--- a/src/PSParallelPipeline/PoolSettings.cs
+++ b/src/PSParallelPipeline/PoolSettings.cs
@@ -2,7 +2,14 @@ using System.Management.Automation.Runspaces;
 
 namespace PSParallelPipeline;
 
-internal record struct PoolSettings(
-    int MaxRunspaces,
-    bool UseNewRunspace,
-    InitialSessionState InitialSessionState);
+internal class PoolSettings(
+    int maxRunspaces,
+    bool useNewRunspace,
+    InitialSessionState initialSessionState)
+{
+    internal int MaxRunspaces { get; } = maxRunspaces;
+
+    internal bool UseNewRunspace { get; } = useNewRunspace;
+
+    internal InitialSessionState InitialSessionState { get; } = initialSessionState;
+}

--- a/src/PSParallelPipeline/TaskSettings.cs
+++ b/src/PSParallelPipeline/TaskSettings.cs
@@ -2,6 +2,11 @@ using System.Collections.Generic;
 
 namespace PSParallelPipeline;
 
-internal record struct TaskSettings(
-    string Script,
-    Dictionary<string, object?> UsingStatements);
+internal class TaskSettings(
+    string script,
+    Dictionary<string, object?> usingStatements)
+{
+    internal string Script { get; } = script;
+
+    internal Dictionary<string, object?> UsingStatements { get; } = usingStatements;
+}

--- a/src/PSParallelPipeline/Worker.cs
+++ b/src/PSParallelPipeline/Worker.cs
@@ -33,17 +33,15 @@ internal sealed class Worker
         _pool = new RunspacePool(poolSettings, _streams, _token);
     }
 
-    internal void Wait() => _worker?.GetAwaiter().GetResult();
+    internal void Wait() => _worker?.ConfigureAwait(false).GetAwaiter().GetResult();
 
     internal void Enqueue(object? input) => _input.Add(input, _token);
 
-    internal bool TryTake(out PSOutputData output) =>
-        _output.TryTake(out output, 0, _token);
+    internal bool TryTake(out PSOutputData output) => _output.TryTake(out output, 0, _token);
 
     internal void CompleteInputAdding() => _input.CompleteAdding();
 
-    internal IEnumerable<PSOutputData> GetConsumingEnumerable() =>
-        _output.GetConsumingEnumerable(_token);
+    internal IEnumerable<PSOutputData> GetConsumingEnumerable() => _output.GetConsumingEnumerable(_token);
 
     internal void Run() => _worker = Task.Run(Start, cancellationToken: _token);
 
@@ -57,13 +55,15 @@ internal sealed class Worker
             {
                 if (tasks.Count == tasks.Capacity)
                 {
-                    await ProcessAnyAsync(tasks);
+                    await ProcessAnyAsync(tasks).ConfigureAwait(false);
                 }
 
-                PSTask task = await PSTask.CreateAsync(
-                    input: input,
-                    runspacePool: _pool,
-                    settings: _taskSettings);
+                PSTask task = await PSTask
+                    .CreateAsync(
+                        input: input,
+                        runspacePool: _pool,
+                        settings: _taskSettings)
+                    .ConfigureAwait(false);
 
                 tasks.Add(task.InvokeAsync());
             }
@@ -72,16 +72,23 @@ internal sealed class Worker
         { }
         finally
         {
-            await Task.WhenAll(tasks);
+            await Task
+                .WhenAll(tasks)
+                .ConfigureAwait(false);
+
             _output.CompleteAdding();
         }
     }
 
     private static async Task ProcessAnyAsync(List<Task> tasks)
     {
-        Task task = await Task.WhenAny(tasks);
+        Task task = await Task
+            .WhenAny(tasks)
+            .ConfigureAwait(false);
+
         tasks.Remove(task);
-        await task;
+        await task
+            .ConfigureAwait(false);
     }
 
     public void Dispose()


### PR DESCRIPTION
When an asynchronous method awaits a [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task?view=net-9.0) directly, continuation usually occurs in the same thread that created the task, depending on the async context. This behavior can be costly in terms of performance and can result in a deadlock on the UI thread. To avoid these problems, call `Task.ConfigureAwait(false)`. For more information, see [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/).